### PR TITLE
Fix three-three-fiber peer dependency typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "pretty-quick": "^2.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-three-fiber": "^4.1.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.7.2",
     "rollup-plugin-babel": "^4.4.0",
@@ -93,6 +92,7 @@
   },
   "peerDependencies": {
     "react": ">=16.13",
-    "react-dom": ">=16.13"
+    "react-dom": ">=16.13",
+    "react-three-fiber": "^4.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
   },
   "peerDependencies": {
     "react": ">=16.13",
-    "react-dom": ">=16.13",
-    "three-three-fiber": ">=4.0"
+    "react-dom": ">=16.13"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,8 +78,6 @@
     "jest": "^25.4.0",
     "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.7.2",
     "rollup-plugin-babel": "^4.4.0",
@@ -91,8 +89,8 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "react": ">=16.13",
-    "react-dom": ">=16.13",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "react-three-fiber": "^4.1.1"
   }
 }


### PR DESCRIPTION
It appears `three-three-fiber` was erroneously added as a peer dependency, which produces a warning on `yarn install`.