### PR TITLE
Fixed children typing in HTML

### DIFF
--- a/src/HTML.tsx
+++ b/src/HTML.tsx
@@ -49,7 +49,6 @@ function objectZIndex(el: Object3D, camera: Camera, zIndexRange: Array<number>) 
 
 export interface HTMLProps
   extends Omit<Assign<React.HTMLAttributes<HTMLDivElement>, ReactThreeFiber.Object3DNode<Group, typeof Group>>, 'ref'> {
-  children: React.ReactElement
   prepend?: boolean
   center?: boolean
   fullscreen?: boolean


### PR DESCRIPTION
In some cases when you have more than one children it may give the following error:

![image](https://user-images.githubusercontent.com/1353142/82213261-29ecc580-9914-11ea-9919-2ccb917a141a.png)

FIX: Removes the children prop, since it is already found in React.HTMLAttributes<HTMLDivElement>