### PR TITLE
Enable adding material as <Text>'s child

### DIFF
--- a/src/Text.tsx
+++ b/src/Text.tsx
@@ -17,12 +17,13 @@ declare global {
 }
 
 type Props = JSX.IntrinsicElements['mesh'] & {
-  children: string
+  children: React.ReactElement
   color?: ReactThreeFiber.Color
   fontSize?: number
   maxWidth?: number
   lineHeight?: number
   letterSpacing?: number
+  text?: string
   textAlign?: 'left' | 'right' | 'center' | 'justify'
   font?: string
   anchorX?: number | 'left' | 'center' | 'right'
@@ -34,5 +35,9 @@ type Props = JSX.IntrinsicElements['mesh'] & {
 }
 
 export const Text = forwardRef(({ children, ...props }: Props, ref) => {
-  return <textMeshImpl ref={ref} text={children} {...props} />
+  return (
+    <textMeshImpl ref={ref} {...props}>
+      {children}
+    </textMeshImpl>
+  )
 })


### PR DESCRIPTION
Thanks for adding <Text> component to drei :)
I think it's more useful to be able to pass children, so we can pass in material and such, like in https://codesandbox.io/embed/troika-3d-text-via-react-three-fiber-ntfx2?fontsize=14

If you think direct import with extension should be used in such cases and drei's helper is meant for material-less simple text, I will drop. 