### PR TITLE
Added AlternativeNormalPass option for StandardEffects

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Adds [ambient-occlusion](https://vanruesc.github.io/postprocessing/public/docs/c
   bloom                     // Can be a boolean or all valid postprocessing Bloom props (default=true)
   edgeDetection={0.1}       // SMAA precision (default=0.1)
   bloomOpacity={1}          // Bloom blendMode opacity (default=1)
+  alternativeNormalPass     // Can be a boolean (default=false), fixes some normal map rendering errors when using instancing
   effects={() => [...fx]}   // Define your own: ([smaa, ao, bloom]) => [...effects] (default=undefined)
 />
 ```

--- a/src/AlternativeNormalPass.ts
+++ b/src/AlternativeNormalPass.ts
@@ -3,7 +3,17 @@
   https://github.com/vanruesc/postprocessing/blob/master/src/passes/NormalPass.js
 */
 
-import { Color, MeshNormalMaterial, NearestFilter, RGBFormat, WebGLRenderTarget, Scene, Camera } from 'three'
+import {
+  Color,
+  MeshNormalMaterial,
+  NearestFilter,
+  RGBFormat,
+  WebGLRenderTarget,
+  Scene,
+  Camera,
+  WebGLRenderer,
+  Object3D,
+} from 'three'
 
 // @ts-ignore
 import { Resizer, Pass, RenderPass } from 'postprocessing'
@@ -27,7 +37,7 @@ export class AlternativeNormalPass extends Pass {
       renderTarget,
     }: { resolutionScale?: number; width?: number; height?: number; renderTarget?: WebGLRenderTarget } = {}
   ) {
-    super('NormalPass')
+    super('AlternativeNormalPass')
 
     this.needsSwap = false
 
@@ -47,7 +57,7 @@ export class AlternativeNormalPass extends Pass {
         stencilBuffer: false,
       })
 
-      this.renderTarget.texture.name = 'NormalPass.Target'
+      this.renderTarget.texture.name = 'AlternativeNormalPass.Target'
     }
 
     this.resolution = new Resizer(this, width, height)
@@ -63,12 +73,12 @@ export class AlternativeNormalPass extends Pass {
     this.setSize(this.originalSize.x, this.originalSize.y)
   }
 
-  render(renderer: any) {
+  render(renderer: WebGLRenderer) {
     const renderTarget = this.renderToScreen ? null : this.renderTarget
     const scene: Scene = this.renderPass.scene
 
     // HACK for instancing: traverse the scene and replace the materials
-    scene.traverse((n: any) => {
+    scene.traverse((n: Object3D & any) => {
       if (n.isMesh) {
         if (!n.normalMaterial) {
           n.normalMaterial = new MeshNormalMaterial()
@@ -82,7 +92,7 @@ export class AlternativeNormalPass extends Pass {
     this.renderPass.render(renderer, renderTarget, renderTarget)
 
     // Restore the old materials
-    scene.traverse((n: any) => {
+    scene.traverse((n: Object3D & any) => {
       if (n.isMesh && n.materialOld) {
         n.material = n.materialOld
       }

--- a/src/AlternativeNormalPass.ts
+++ b/src/AlternativeNormalPass.ts
@@ -1,3 +1,8 @@
+/*
+  Altered version of NormalPass.ts from postprocessing.js
+  https://github.com/vanruesc/postprocessing/blob/master/src/passes/NormalPass.js
+*/
+
 import { Color, MeshNormalMaterial, NearestFilter, RGBFormat, WebGLRenderTarget, Scene, Camera } from 'three'
 
 // @ts-ignore

--- a/src/AlternativeNormalPass.ts
+++ b/src/AlternativeNormalPass.ts
@@ -1,0 +1,98 @@
+import { Color, MeshNormalMaterial, NearestFilter, RGBFormat, WebGLRenderTarget, Scene, Camera } from 'three'
+
+// @ts-ignore
+import { Resizer, Pass, RenderPass } from 'postprocessing'
+
+export class AlternativeNormalPass extends Pass {
+  needsSwap: boolean
+  renderPass: any
+  resolution: any
+  originalSize: any
+  renderTarget?: WebGLRenderTarget
+  resolutionScale?: number
+  renderToScreen?: boolean
+
+  constructor(
+    scene: Scene,
+    camera: Camera,
+    {
+      resolutionScale = 1.0,
+      width = Resizer.AUTO_SIZE,
+      height = Resizer.AUTO_SIZE,
+      renderTarget,
+    }: { resolutionScale?: number; width?: number; height?: number; renderTarget?: WebGLRenderTarget } = {}
+  ) {
+    super('NormalPass')
+
+    this.needsSwap = false
+
+    this.renderPass = new RenderPass(scene, camera)
+
+    const clearPass = this.renderPass.getClearPass()
+    clearPass.overrideClearColor = new Color(0x7777ff)
+    clearPass.overrideClearAlpha = 1.0
+
+    this.renderTarget = renderTarget
+
+    if (this.renderTarget === undefined) {
+      this.renderTarget = new WebGLRenderTarget(1, 1, {
+        minFilter: NearestFilter,
+        magFilter: NearestFilter,
+        format: RGBFormat,
+        stencilBuffer: false,
+      })
+
+      this.renderTarget.texture.name = 'NormalPass.Target'
+    }
+
+    this.resolution = new Resizer(this, width, height)
+    this.resolution.scale = resolutionScale
+  }
+
+  getResolutionScale() {
+    return this.resolutionScale
+  }
+
+  setResolutionScale(scale: any) {
+    this.resolutionScale = scale
+    this.setSize(this.originalSize.x, this.originalSize.y)
+  }
+
+  render(renderer: any) {
+    const renderTarget = this.renderToScreen ? null : this.renderTarget
+    const scene: Scene = this.renderPass.scene
+
+    // HACK for instancing: traverse the scene and replace the materials
+    scene.traverse((n: any) => {
+      if (n.isMesh) {
+        if (!n.normalMaterial) {
+          n.normalMaterial = new MeshNormalMaterial()
+        }
+
+        n.materialOld = n.material
+        n.material = n.normalMaterial
+      }
+    })
+
+    this.renderPass.render(renderer, renderTarget, renderTarget)
+
+    // Restore the old materials
+    scene.traverse((n: any) => {
+      if (n.isMesh && n.materialOld) {
+        n.material = n.materialOld
+      }
+    })
+  }
+
+  setSize(width: number, height: number) {
+    const resolution = this.resolution
+    resolution.base.set(width, height)
+
+    width = resolution.width
+    height = resolution.height
+
+    if (this.renderTarget) {
+      this.renderTarget.setSize(width, height)
+    }
+  }
+}

--- a/src/StandardEffects.tsx
+++ b/src/StandardEffects.tsx
@@ -14,6 +14,7 @@ import {
   NormalPass,
   // @ts-ignore
 } from 'postprocessing'
+import { AlternativeNormalPass } from './AlternativeNormalPass'
 
 type Props = {
   bloom?: boolean | BloomProps
@@ -21,6 +22,7 @@ type Props = {
   smaa?: boolean
   edgeDetection?: number
   bloomOpacity?: number
+  alternativeNormalPass?: boolean
   effects?: (effects: any[]) => any[]
 }
 
@@ -53,6 +55,7 @@ export function StandardEffects({
   bloom = true,
   edgeDetection = 0.1,
   bloomOpacity = 1,
+  alternativeNormalPass = false,
   effects,
 }: Props) {
   const { gl, scene, camera, size } = useThree()
@@ -63,7 +66,7 @@ export function StandardEffects({
     const smaaEffect = new SMAAEffect(...smaaProps)
     smaaEffect.colorEdgesMaterial.setEdgeDetectionThreshold(edgeDetection)
 
-    const normalPass = new NormalPass(scene, camera)
+    const normalPass = new (alternativeNormalPass ? AlternativeNormalPass : NormalPass)(scene, camera)
     const ssaoEffect = new SSAOEffect(camera, normalPass.renderTarget.texture, {
       blendFunction: BlendFunction.MULTIPLY,
       samples: 21, // May get away with less samples


### PR DESCRIPTION
As shown in Issue #18, when you combine instancing and SSAO the rendering breaks, since it uses internally `scene.overrideMaterial`. It's not possible to use a single material for instanced and non instanced objects, since the program attributes are different.

I've noticed that using this approach it's pretty difficult to make a fix, so I've found an hack: you can render a Normal Map, even with instancing, only if you use separate MeshNormalMaterials, traversing the scene tree and temporarily exchanging the materials.

I acknowledge that this can be a corner case or an hack, but it may be useful for someone…