### PR TITLE
Forward transforms to wrapped group

### DIFF
--- a/src/TransformControls.tsx
+++ b/src/TransformControls.tsx
@@ -19,7 +19,7 @@ declare global {
 }
 
 export const TransformControls = forwardRef(
-  ({ children, ...props }: { children: React.ReactElement<Object3D> } & TransformControls, ref) => {
+  ({ children, position, rotation, scale, ...props }: { children: React.ReactElement<Object3D> } & TransformControls, ref) => {
     const controls = useRef<TransformControlsImpl>()
     const group = useRef<Group>()
     const { camera, gl, invalidate } = useThree()
@@ -31,7 +31,7 @@ export const TransformControls = forwardRef(
     return (
       <>
         <transformControlsImpl ref={mergeRefs([controls, ref])} args={[camera, gl.domElement]} {...props} />
-        <group ref={group}>{children}</group>
+        <group ref={group} position={position} rotation={rotation} scale={scale}>{children}</group>
       </>
     )
   }

--- a/src/TransformControls.tsx
+++ b/src/TransformControls.tsx
@@ -19,7 +19,7 @@ declare global {
 }
 
 export const TransformControls = forwardRef(
-  ({ children, position, rotation, scale, ...props }: { children: React.ReactElement<Object3D> } & TransformControls, ref) => {
+  ({ children, enabled, axis, mode, translationSnap, rotationSnap, scaleSnap, space, size, dragging, showX, showY, showZ, ...props }: { children: React.ReactElement<Object3D> } & TransformControls, ref) => {
     const controls = useRef<TransformControlsImpl>()
     const group = useRef<Group>()
     const { camera, gl, invalidate } = useThree()
@@ -30,8 +30,8 @@ export const TransformControls = forwardRef(
     }, [controls.current])
     return (
       <>
-        <transformControlsImpl ref={mergeRefs([controls, ref])} args={[camera, gl.domElement]} {...props} />
-        <group ref={group} position={position} rotation={rotation} scale={scale}>{children}</group>
+        <transformControlsImpl ref={mergeRefs([controls, ref])} args={[camera, gl.domElement]} enabled={enabled} axis={axis} mode={mode} translationSnap={translationSnap} rotationSnap={rotationSnap} scaleSnap={scaleSnap} space={space} size={size} dragging={dragging} showX={showX} showY={showY} showZ={showZ} />
+        <group ref={group} {...props}>{children}</group>
       </>
     )
   }


### PR DESCRIPTION
Fixes #21.

When used, only set transforms on `<TransformControls/>` but not in the wrapped object, e.g.

```jsx
<TransformControls position={props.position}>
	<mesh>
		{/* geometry and material omitted for brevity */}
	</mesh>
</TransformControls>
```