### PR TITLE
Fixes error in shapes

### DIFF
--- a/src/shapes.tsx
+++ b/src/shapes.tsx
@@ -24,7 +24,7 @@ import React, { forwardRef } from 'react'
 type Args<T> = T extends new (...args: any) => any ? ConstructorParameters<T> : T
 
 function create<T>(type: string) {
-  const El: any = type + 'bufferGeometry'
+  const El: any = type + 'BufferGeometry'
   return forwardRef(
     ({ args, children, ...props }: Omit<JSX.IntrinsicElements['mesh'], 'args'> & { args?: Args<T> }, ref) => (
       <mesh ref={ref as React.MutableRefObject<Mesh>} {...props}>


### PR DESCRIPTION
Shapes don't work atm, since the lowercase b makes the name "boxbufferGeometry" instead of the correct camel name