### PR TITLE
enable optional classname on Stats to allow custom styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Adds [stats](https://github.com/mrdoob/stats.js/) to document.body. It takes ove
 ```jsx
 <Stats
   showPanel={0}             // Start-up panel (default=0)
+  className='stats'         // Optional className to add to the stats container dom element
   {...props}                // All stats.js props are valid
 />
 ```

--- a/src/Stats.tsx
+++ b/src/Stats.tsx
@@ -13,7 +13,7 @@ export function Stats({ showPanel = 0, className }: Props): null {
   useEffect(() => {
     stats.showPanel(showPanel)
     document.body.appendChild(stats.dom)
-    stats.dom.classList.add(className)
+    if (className) stats.dom.classList.add(className)
     return () => document.body.removeChild(stats.dom)
   }, [])
   return useFrame((state) => {

--- a/src/Stats.tsx
+++ b/src/Stats.tsx
@@ -3,11 +3,17 @@ import { useFrame } from 'react-three-fiber'
 // @ts-ignore
 import StatsImpl from 'stats.js'
 
-export function Stats({ showPanel = 0 }) {
+type Props = {
+  showPanel?: number
+  className?: string
+}
+
+export function Stats({ showPanel = 0, className }: Props): null {
   const [stats] = useState(() => new (StatsImpl as any)())
   useEffect(() => {
     stats.showPanel(showPanel)
     document.body.appendChild(stats.dom)
+    stats.dom.classList.add(className)
     return () => document.body.removeChild(stats.dom)
   }, [])
   return useFrame((state) => {


### PR DESCRIPTION
I recently needed to use Stats, but couldn't have it in the top left corner because of existing UI elements, so I made this modification to allow a className to be added to the container so I could target with css.

The only downside is having to use `important` in the css to actually move the damn thing because of the inline styles, but it still seems to be the simplest solution to add a touch of customisation without a load of custom props.