### PR TITLE
Make `time` property optional in MeshWobbleMaterial so it works in TypeScript

### DIFF
--- a/src/MeshWobbleMaterial.tsx
+++ b/src/MeshWobbleMaterial.tsx
@@ -5,7 +5,7 @@ import { extend, useFrame, ReactThreeFiber } from 'react-three-fiber'
 import mergeRefs from 'react-merge-refs'
 
 type WobbleMaterialType = JSX.IntrinsicElements['meshStandardMaterial'] & {
-  time: number
+  time?: number
   factor: number
 }
 


### PR DESCRIPTION
Make `time` optional because it's not required for the effect to work