### PR TITLE
Add prop for Stats to allow specifying where to add it in the DOM

### DIFF
--- a/src/Stats.tsx
+++ b/src/Stats.tsx
@@ -6,15 +6,17 @@ import StatsImpl from 'stats.js'
 type Props = {
   showPanel?: number
   className?: string
+  domElement?: HTMLElement
 }
 
-export function Stats({ showPanel = 0, className }: Props): null {
+export function Stats({ showPanel = 0, className, domElement }: Props): null {
   const [stats] = useState(() => new (StatsImpl as any)())
   useEffect(() => {
     stats.showPanel(showPanel)
-    document.body.appendChild(stats.dom)
+    const elem = domElement || document.body;
+    elem.appendChild(stats.dom)
     if (className) stats.dom.classList.add(className)
-    return () => document.body.removeChild(stats.dom)
+    return () => elem.removeChild(stats.dom)
   }, [])
   return useFrame((state) => {
     stats.begin()

--- a/src/Stats.tsx
+++ b/src/Stats.tsx
@@ -6,14 +6,14 @@ import StatsImpl from 'stats.js'
 type Props = {
   showPanel?: number
   className?: string
-  domElement?: HTMLElement
+  domElement?: Node
 }
 
 export function Stats({ showPanel = 0, className, domElement }: Props): null {
   const [stats] = useState(() => new (StatsImpl as any)())
   useEffect(() => {
     stats.showPanel(showPanel)
-    const elem = domElement || document.body;
+    const elem = domElement || document.body
     elem.appendChild(stats.dom)
     if (className) stats.dom.classList.add(className)
     return () => elem.removeChild(stats.dom)


### PR DESCRIPTION
This is useful when the Stats widget is suitable for placing with a canvas that is not a full screen canvas. 

Unsure if the proper type is `HTMLElement` or `Node`, but I have confirmed that this is functional in my app.