### PR TITLE
Adds .npmignore file to ignore storybook files in npm releases

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.storybook
+storybook-static


### PR DESCRIPTION
@drcmda I added this to make sure storybook files are not included in the npm package - since there are actual draco binaries, sounds, etc

