### PR TITLE
Added <DeviceOrientationControls/>

### DIFF
--- a/.storybook/stories/DeviceOrientationControls.stories.js
+++ b/.storybook/stories/DeviceOrientationControls.stories.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Setup } from '../Setup'
+import { DeviceOrientationControls } from '../../src/DeviceOrientationControls'
+import { Box } from '../../src/shapes'
+
+export function DeviceOrientationControlsStory() {
+  return (
+    <>
+      <DeviceOrientationControls />
+      <Box args={[100, 100, 100, 4, 4, 4]}>
+        <meshBasicMaterial attach="material" wireframe />
+        <axesHelper args={[100]} />
+      </Box>
+    </>
+  )
+}
+
+DeviceOrientationControlsStory.storyName = 'Default'
+
+export default {
+  title: 'Controls/DeviceOrientationControls',
+  component: DeviceOrientationControls,
+  decorators: [
+    (storyFn) => (
+      <Setup camera={{ near: 1, far: 1100, fov: 75 }} controls={false}>
+        {storyFn()}
+      </Setup>
+    ),
+  ],
+}

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Run the demo storybook on your computer:
 - Controls
   - `<OrbitControls/>` [![](https://img.shields.io/badge/-codesandbox-blue)](https://codesandbox.io/s/r3f-contact-shadow-h5xcw)
   - `<MapControls/>` [![](https://img.shields.io/badge/-codesandbox-blue)](https://codesandbox.io/s/react-three-fiber-map-mkq8e)
+  - `<DeviceOrientationControls/>`
   - `<TrackballControls/>`
   - `<TransformControls/>` [![](https://img.shields.io/badge/-codesandbox-blue)](https://codesandbox.io/s/r3f-drei-transformcontrols-hc8gm)
 - Shapes

--- a/src/DeviceOrientationControls.tsx
+++ b/src/DeviceOrientationControls.tsx
@@ -1,0 +1,33 @@
+import React, { forwardRef, useRef, useEffect } from 'react'
+import { ReactThreeFiber, extend, useThree, useFrame, Overwrite } from 'react-three-fiber'
+import { DeviceOrientationControls as DeviceOrientationControlsImp } from 'three/examples/jsm/controls/DeviceOrientationControls'
+// @ts-ignore
+import mergeRefs from 'react-merge-refs'
+
+extend({ DeviceOrientationControlsImp })
+
+export type DeviceOrientationControls = Overwrite<
+  ReactThreeFiber.Object3DNode<DeviceOrientationControlsImp, typeof DeviceOrientationControlsImp>,
+  { target?: ReactThreeFiber.Vector3 }
+>
+
+declare global {
+  namespace JSX {
+    // eslint-disable-next-line @typescript-eslint/interface-name-prefix
+    interface IntrinsicElements {
+      deviceOrientationControlsImp: DeviceOrientationControls
+    }
+  }
+}
+
+export const DeviceOrientationControls = forwardRef((props: DeviceOrientationControls, ref) => {
+  const controls = useRef<DeviceOrientationControlsImp>()
+  const { camera } = useThree()
+  useFrame(() => controls.current?.update())
+  useEffect(() => {
+    const currentControl = controls.current
+    currentControl?.connect()
+    return () => currentControl?.dispose()
+  })
+  return <deviceOrientationControlsImp ref={mergeRefs([controls, ref])} args={[camera]} {...props} />
+})


### PR DESCRIPTION
This will provide a component, storybook example, and a README.md update. DeviceOrientationControls is one of five missing controls. It could be useful for those wanting to provide mobile interactions and could reduce redundancy for self-implementations of this control.