### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,17 +289,23 @@ import glsl from "babel-plugin-glsl/macro"
 
 const ColorShiftMaterial = shaderMaterial(
   { time: 0, color: new THREE.Color(0.2, 0.0, 0.1) },
-  glsl`varying vec2 vUv;
+  // vertex shader
+  glsl`
+    varying vec2 vUv;
     void main() {
       vUv = uv;
       gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-    }`,
-  glsl`uniform float time;
+    }
+  `,
+  // fragment shader
+  glsl`
+    uniform float time;
     uniform vec3 color;
     varying vec2 vUv;
     void main() {
       gl_FragColor.rgba = vec4(0.5 + 0.3 * sin(vUv.yxx + time) + color, 1.0);
-    }`
+    }
+  `
 )
 
 extend({ ColorShiftMaterial })


### PR DESCRIPTION
I adjusted shaderMaterial excerpt to have more clarity.

Since the arguments are comma-deliminated, it might not be clear that the order is:
`shaderMaterial(uniforms, vertexShader, fragmentShader)`.

For this excerpt, I think adding a comment above each of the shaders helps add clarity since they look otherwise similar.

Also, maybe this is a personal formatting preference, but for template strings, it is far more readable to drop to the next line after the grave `. This follows the precedent of how the examples like [styled-components](https://styled-components.com/docs/api#styled), [graphql-tag](https://github.com/apollographql/graphql-tag#gql), and others work.