### PR TITLE
making drei treeshakable

### DIFF
--- a/.storybook/stories/MeshDistortMaterial.stories.js
+++ b/.storybook/stories/MeshDistortMaterial.stories.js
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useRef } from 'react'
 
 import { withKnobs, number } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 import { MeshDistortMaterial } from '../../src/shaders/MeshDistortMaterial'
 import { Icosahedron } from '../../src/shapes'
+import { useFrame } from 'react-three-fiber'
 
 export default {
   title: 'Shaders/MeshDistortMaterial',
@@ -28,3 +29,25 @@ function MeshDistortMaterialScene() {
 
 export const MeshDistortMaterialSt = () => <MeshDistortMaterialScene />
 MeshDistortMaterialSt.storyName = 'Default'
+
+function MeshDistortMaterialRefScene() {
+
+  const material = useRef()
+
+  useFrame(({ clock }) => {
+    material.current.distort = Math.sin(clock.getElapsedTime())
+  })
+  
+  return (
+    <Icosahedron args={[1, 4]}>
+      <MeshDistortMaterial
+        attach="material"
+        color="#f25042"
+        ref={material}
+      />
+    </Icosahedron>
+  )
+}
+
+export const MeshDistortMaterialRefSt = () => <MeshDistortMaterialRefScene />
+MeshDistortMaterialRefSt.storyName = 'Ref'

--- a/.storybook/stories/MeshWobbleMaterial.stories.js
+++ b/.storybook/stories/MeshWobbleMaterial.stories.js
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useRef } from 'react'
 
 import { withKnobs, number } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 import { MeshWobbleMaterial } from '../../src/shaders/MeshWobbleMaterial'
 import { Torus } from '../../src/shapes'
+import { useFrame } from 'react-three-fiber'
 
 export default {
   title: 'Shaders/MeshWobbleMaterial',
@@ -27,3 +28,26 @@ function MeshWobbleMaterialScene() {
 
 export const MeshWobbleMaterialSt = () => <MeshWobbleMaterialScene />
 MeshWobbleMaterialSt.storyName = 'Default'
+
+function MeshWobbleMaterialRefScene() {
+
+  const material = useRef()
+
+  useFrame(({ clock }) => {
+    material.current.factor = Math.abs(Math.sin(clock.getElapsedTime())) * 2
+    material.current.speed = Math.abs(Math.sin(clock.getElapsedTime())) * 10
+  })
+  
+  return (
+    <Torus args={[1, 0.25, 16, 100]}>
+      <MeshWobbleMaterial
+        attach="material"
+        color="#f25042"
+        ref={material}
+      />
+    </Torus>
+  )
+}
+
+export const MeshWobbleMaterialRefSt = () => <MeshWobbleMaterialRefScene />
+MeshWobbleMaterialRefSt.storyName = 'Ref'

--- a/.storybook/stories/Reflector.stories.js
+++ b/.storybook/stories/Reflector.stories.js
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, {useRef} from 'react'
+import { useFrame } from 'react-three-fiber'
 
 import { Setup } from '../Setup'
-import { MeshWobbleMaterial, Reflector } from '../../src/misc/Reflector'
+import { Reflector } from '../../src/misc/Reflector'
+import { Box } from '../../src/shapes'
 
 export default {
   title: 'Misc/Reflector',
@@ -10,15 +12,28 @@ export default {
 }
 
 function ReflectorScene() {
+  const $box = useRef()
+  useFrame(({ clock }) => {
+    $box.current.position.y += Math.sin(clock.getElapsedTime()) / 100. 
+    $box.current.rotation.y = clock.getElapsedTime() / 2.
+  })
+  
   return (
-    <>
-      <Reflector>
-        <planeBufferGeometry args={[2, 5]} attach="geometry" />
+    <>  
+      <Reflector 
+        clipBias={0.1} 
+        textureWidth={1024}
+        textureHeight={1024}
+        rotation={[-Math.PI/2, 0, 0]} 
+        color="#333" 
+        opacity={.5}
+      >
+        <planeBufferGeometry args={[10, 10]} attach="geometry" />
       </Reflector>
-      <mesh position={[0, -2, 2]}>
-        <boxBufferGeometry attach="geometry" />
-        <meshBasicMaterial attach="material" color="red" opacity={1} transparent />
-      </mesh>
+
+      <Box position={[-2, 1, -1]} material-color="hotpink" material-wireframe />
+      <Box args={[2, 2, 2]} ref={$box} position={[0, 1, 0]} material-color="hotpink" />
+      <Box position={[2, 1, 1]} material-color="hotpink" material-wireframe />
     </>
   )
 }

--- a/.storybook/stories/Sky.stories.js
+++ b/.storybook/stories/Sky.stories.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { withKnobs, number } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 
@@ -8,13 +9,13 @@ import { Plane } from '../../src/shapes'
 export default {
   title: 'Shaders/Sky',
   component: Sky,
-  decorators: [(storyFn) => <Setup> {storyFn()}</Setup>],
+  decorators: [withKnobs, (storyFn) => <Setup> {storyFn()}</Setup>],
 }
 
 function SkyScene() {
   return (
     <>
-      <Sky sunPosition={[0, Math.PI, -1]} />
+      <Sky />
       <Plane rotation-x={Math.PI / 2} args={[100, 100, 4, 4]}>
         <meshBasicMaterial color="black" wireframe attach="material" />
       </Plane>
@@ -25,3 +26,23 @@ function SkyScene() {
 
 export const SkySt = () => <SkyScene />
 SkySt.storyName = 'Default'
+
+function SkyScene2() {
+  return (
+    <>
+      <Sky 
+        distance={3000} 
+        turbidity={number('Turbidity', 8, { range: true, max: 10, step: 0.1 })} 
+        rayleigh={number('Rayleigh', 6, { range: true, max: 10, step: 0.1 })} 
+        sunPosition={[Math.PI, 0, 0]}
+        />
+      <Plane rotation-x={Math.PI / 2} args={[100, 100, 4, 4]}>
+        <meshBasicMaterial color="black" wireframe attach="material" />
+      </Plane>
+      <axesHelper />
+    </>
+  )
+}
+
+export const SkySt2 = () => <SkyScene2 />
+SkySt2.storyName = 'Another one'

--- a/.storybook/stories/Sky.stories.js
+++ b/.storybook/stories/Sky.stories.js
@@ -34,6 +34,8 @@ function SkyScene2() {
         distance={3000} 
         turbidity={number('Turbidity', 8, { range: true, max: 10, step: 0.1 })} 
         rayleigh={number('Rayleigh', 6, { range: true, max: 10, step: 0.1 })} 
+        mieCoefficient={number('mieCoefficient', 0.005, { range: true, max: 0.1, step: 0.001 })} 
+        mieDirectionalG={number('mieDirectionalG', 0.8, { range: true, max: 1., step: 0.01 })} 
         sunPosition={[Math.PI, 0, 0]}
         />
       <Plane rotation-x={Math.PI / 2} args={[100, 100, 4, 4]}>

--- a/.storybook/stories/shaderMaterial.stories.js
+++ b/.storybook/stories/shaderMaterial.stories.js
@@ -1,0 +1,76 @@
+import React, { Suspense, useRef } from 'react'
+
+import { withKnobs, number } from '@storybook/addon-knobs'
+
+import { Setup } from '../Setup'
+import { MeshDistortMaterial } from '../../src/shaders/MeshDistortMaterial'
+import { Box, Icosahedron } from '../../src/shapes'
+import { extend } from 'react-three-fiber'
+
+import { shaderMaterial, useTextureLoader } from '../../src/'
+
+export default {
+  title: 'Shaders/shaderMaterial',
+  component: MeshDistortMaterial,
+  decorators: [withKnobs, (storyFn) => <Setup> {storyFn()}</Setup>],
+}
+
+const MyMaterial = shaderMaterial({ map: null, repeats: 1 }, `
+varying vec2 vUv;
+
+void main()	{
+  vUv = uv;
+  
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.);
+}
+`, `
+varying vec2 vUv;
+uniform float repeats;
+uniform sampler2D map;
+
+float random (vec2 st) {
+  return fract(sin(dot(st.xy,
+                       vec2(12.9898,78.233)))*
+      43758.5453123);
+}
+
+void main(){
+  vec2 uv = vUv;
+
+  uv *= repeats;
+  uv = fract(uv);
+
+  vec3 color = vec3(
+    texture2D(map, uv).r,
+    texture2D(map, uv + vec2(0.01,0.01)).g,
+    texture2D(map, uv - vec2(0.01,0.01)).b
+  );
+  
+  gl_FragColor = vec4(color,1.0);
+}
+`)
+
+extend({ MyMaterial })
+
+function ShaderMaterialScene() {
+
+  const map = useTextureLoader(`https://source.unsplash.com/random/400x400`)
+  
+  return (
+    <Box args={[5, 5, 5]}>
+    
+      <myMaterial
+        repeats={number("repeats", 2, { range: true, min: 1, max: 10, step: 1 })}
+        map={map}
+        attach="material"
+      />
+      
+    </Box>
+  )
+}
+
+
+export const ShaderMaterialStory = () => <Suspense fallback={null}>
+<ShaderMaterialScene />
+</Suspense>
+ShaderMaterialStory.storyName = 'Default'

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-three-fiber": "^4.2.16",
+    "react-three-fiber": "^4.2.21",
     "rimraf": "^3.0.2",
     "rollup": "^2.26.4",
     "rollup-plugin-babel": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-size-snapshot": "^0.12.0",
-    "three": "^0.119.1",
+    "three": "^0.120.1",
     "typescript": "^3.9.7"
   },
   "peerDependencies": {

--- a/src/abstractions/Line.tsx
+++ b/src/abstractions/Line.tsx
@@ -30,9 +30,10 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
     line2.computeLineDistances()
   }, [points, vertexColors, line2, lineGeometry])
   return (
-    <primitive object={line2} ref={ref} {...rest}>
-      <primitive object={lineGeometry} attach="geometry" />
+    <primitive dispose={null} object={line2} ref={ref} {...rest}>
+      <primitive dispose={null} object={lineGeometry} attach="geometry" />
       <primitive
+        dispose={null}
         object={lineMaterial}
         attach="material"
         color={color}

--- a/src/abstractions/Line.tsx
+++ b/src/abstractions/Line.tsx
@@ -1,48 +1,39 @@
 import * as THREE from 'three'
-import React, { useMemo, useEffect, useRef } from 'react'
-import { extend, ReactThreeFiber } from 'react-three-fiber'
+import React, { useMemo, useEffect, useState } from 'react'
+import { ReactThreeFiber } from 'react-three-fiber'
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry'
 import { LineMaterial, LineMaterialParameters } from 'three/examples/jsm/lines/LineMaterial'
 import { Line2 } from 'three/examples/jsm/lines/Line2'
-import mergeRefs from 'react-merge-refs'
-
-extend({ Line2, LineGeometry, LineMaterial })
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      line2: ReactThreeFiber.Object3DNode<Line2, typeof Line2>
-      lineGeometry: ReactThreeFiber.Object3DNode<LineGeometry, typeof LineGeometry>
-      lineMaterial: ReactThreeFiber.MaterialNode<LineMaterial, [LineMaterialParameters]>
-    }
-  }
-}
 
 type Props = {
   points: [number, number, number][]
   color?: THREE.Color | string | number
   vertexColors?: [number, number, number][]
   lineWidth?: number
-} & Omit<JSX.IntrinsicElements['line2'], 'args'> &
-  Omit<JSX.IntrinsicElements['lineMaterial'], 'color' | 'vertexColors' | 'resolution' | 'args'>
+} & Omit<ReactThreeFiber.Object3DNode<Line2, typeof Line2>, 'args'> &
+  Omit<
+    ReactThreeFiber.Object3DNode<LineMaterial, [LineMaterialParameters]>,
+    'color' | 'vertexColors' | 'resolution' | 'args'
+  >
 
 export const Line = React.forwardRef<Line2, Props>(function Line(
   { points, color = 'black', vertexColors, lineWidth, ...rest },
   ref
 ) {
-  const lineRef = useRef<Line2>()
-  const geomRef = useRef<LineGeometry>()
+  const [line2] = useState(() => new Line2())
+  const [lineGeometry] = useState(() => new LineGeometry())
+  const [lineMaterial] = useState(() => new LineMaterial())
   const resolution = useMemo(() => new THREE.Vector2(512, 512), [])
   useEffect(() => {
-    if (!geomRef.current || !lineRef.current) return
-    geomRef.current.setPositions(points.flat())
-    if (vertexColors) geomRef.current.setColors(vertexColors.flat())
-    lineRef.current.computeLineDistances()
-  }, [points, vertexColors])
+    lineGeometry.setPositions(points.flat())
+    if (vertexColors) lineGeometry.setColors(vertexColors.flat())
+    line2.computeLineDistances()
+  }, [points, vertexColors, line2, lineGeometry])
   return (
-    <line2 ref={mergeRefs([lineRef, ref])} {...rest}>
-      <lineGeometry attach="geometry" ref={geomRef} />
-      <lineMaterial
+    <primitive object={line2} ref={ref} {...rest}>
+      <primitive object={lineGeometry} attach="geometry" />
+      <primitive
+        object={lineMaterial}
         attach="material"
         color={color}
         vertexColors={Boolean(vertexColors)}
@@ -50,6 +41,6 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
         linewidth={lineWidth}
         {...rest}
       />
-    </line2>
+    </primitive>
   )
 })

--- a/src/abstractions/Text.tsx
+++ b/src/abstractions/Text.tsx
@@ -36,7 +36,14 @@ export const Text = forwardRef(({ anchorX = 'center', anchorY = 'middle', childr
         // Once the base material has been assigned, grab the resulting upgraded material,
         // and apply the original material props to that.
         if (baseMtl) {
-          n.push(<primitive object={troikaMesh.material} {...(child as React.ReactElement).props} attach={null} />)
+          n.push(
+            <primitive
+              dispose={null}
+              object={troikaMesh.material}
+              {...(child as React.ReactElement).props}
+              attach={null}
+            />
+          )
         }
       } else {
         n.push(child)
@@ -46,7 +53,7 @@ export const Text = forwardRef(({ anchorX = 'center', anchorY = 'middle', childr
   }, [children, baseMtl, troikaMesh.material])
   useLayoutEffect(() => void troikaMesh.sync(invalidate))
   return (
-    <primitive object={troikaMesh} ref={ref} text={text} anchorX={anchorX} anchorY={anchorY} {...props}>
+    <primitive dispose={null} object={troikaMesh} ref={ref} text={text} anchorX={anchorX} anchorY={anchorY} {...props}>
       {nodes}
     </primitive>
   )

--- a/src/abstractions/Text.tsx
+++ b/src/abstractions/Text.tsx
@@ -1,19 +1,6 @@
-import React, { Children, createElement, forwardRef, useMemo, useRef, useLayoutEffect, useState } from 'react'
+import React, { Children, createElement, forwardRef, useMemo, useLayoutEffect, useState } from 'react'
 import { Text as TextMeshImpl } from 'troika-three-text'
-import { extend, ReactThreeFiber, useThree } from 'react-three-fiber'
-import mergeRefs from 'react-merge-refs'
-
-extend({ TextMeshImpl })
-
-type TextMesh = ReactThreeFiber.Object3DNode<TextMeshImpl, typeof TextMeshImpl>
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      textMeshImpl: TextMesh
-    }
-  }
-}
+import { ReactThreeFiber, useThree } from 'react-three-fiber'
 
 type Props = JSX.IntrinsicElements['mesh'] & {
   children: React.ReactNode
@@ -34,7 +21,7 @@ type Props = JSX.IntrinsicElements['mesh'] & {
 
 export const Text = forwardRef(({ anchorX = 'center', anchorY = 'middle', children, ...props }: Props, ref) => {
   const { invalidate } = useThree()
-  const textRef = useRef<TextMeshImpl>()
+  const [troikaMesh] = useState(() => new TextMeshImpl())
   const [baseMtl, setBaseMtl] = useState()
   const [nodes, text] = useMemo(() => {
     let n: React.ReactNode[] = []
@@ -49,19 +36,18 @@ export const Text = forwardRef(({ anchorX = 'center', anchorY = 'middle', childr
         // Once the base material has been assigned, grab the resulting upgraded material,
         // and apply the original material props to that.
         if (baseMtl) {
-          n.push(<primitive object={textRef.current.material} {...(child as React.ReactElement).props} attach={null} />)
+          n.push(<primitive object={troikaMesh.material} {...(child as React.ReactElement).props} attach={null} />)
         }
       } else {
         n.push(child)
       }
     })
     return [n, t]
-  }, [children, baseMtl])
-  useLayoutEffect(() => void textRef.current.sync(invalidate))
-
+  }, [children, baseMtl, troikaMesh.material])
+  useLayoutEffect(() => void troikaMesh.sync(invalidate))
   return (
-    <textMeshImpl ref={mergeRefs([textRef, ref])} text={text} anchorX={anchorX} anchorY={anchorY} {...props}>
+    <primitive object={troikaMesh} ref={ref} text={text} anchorX={anchorX} anchorY={anchorY} {...props}>
       {nodes}
-    </textMeshImpl>
+    </primitive>
   )
 })

--- a/src/controls/DeviceOrientationControls.tsx
+++ b/src/controls/DeviceOrientationControls.tsx
@@ -15,6 +15,6 @@ export const DeviceOrientationControls = forwardRef((props: DeviceOrientationCon
     const current = controls
     current.connect()
     return () => current.dispose()
-  }, [])
+  }, [controls])
   return <primitive object={controls} ref={ref} {...props} />
 })

--- a/src/controls/DeviceOrientationControls.tsx
+++ b/src/controls/DeviceOrientationControls.tsx
@@ -24,5 +24,5 @@ export const DeviceOrientationControls = forwardRef((props: DeviceOrientationCon
     return () => current.dispose()
   }, [controls])
 
-  return <primitive object={controls} ref={ref} {...props} />
+  return <primitive dispose={null} object={controls} ref={ref} {...props} />
 })

--- a/src/controls/DeviceOrientationControls.tsx
+++ b/src/controls/DeviceOrientationControls.tsx
@@ -8,13 +8,21 @@ export type DeviceOrientationControls = Overwrite<
 >
 
 export const DeviceOrientationControls = forwardRef((props: DeviceOrientationControls, ref) => {
-  const { camera } = useThree()
+  const { camera, invalidate } = useThree()
   const controls = useMemo(() => new DeviceOrientationControlsImp(camera), [camera])
+
+  useEffect(() => {
+    controls?.addEventListener?.('change', invalidate)
+    return () => controls?.removeEventListener?.('change', invalidate)
+  }, [controls, invalidate])
+
   useFrame(() => controls.update())
+
   useEffect(() => {
     const current = controls
     current.connect()
     return () => current.dispose()
   }, [controls])
+
   return <primitive object={controls} ref={ref} {...props} />
 })

--- a/src/controls/DeviceOrientationControls.tsx
+++ b/src/controls/DeviceOrientationControls.tsx
@@ -1,31 +1,20 @@
-import React, { forwardRef, useRef, useEffect } from 'react'
-import { ReactThreeFiber, extend, useThree, useFrame, Overwrite } from 'react-three-fiber'
+import React, { forwardRef, useMemo, useEffect } from 'react'
+import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { DeviceOrientationControls as DeviceOrientationControlsImp } from 'three/examples/jsm/controls/DeviceOrientationControls'
-import mergeRefs from 'react-merge-refs'
-
-extend({ DeviceOrientationControlsImp })
 
 export type DeviceOrientationControls = Overwrite<
   ReactThreeFiber.Object3DNode<DeviceOrientationControlsImp, typeof DeviceOrientationControlsImp>,
   { target?: ReactThreeFiber.Vector3 }
 >
 
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      deviceOrientationControlsImp: DeviceOrientationControls
-    }
-  }
-}
-
 export const DeviceOrientationControls = forwardRef((props: DeviceOrientationControls, ref) => {
-  const controls = useRef<DeviceOrientationControlsImp>()
   const { camera } = useThree()
-  useFrame(() => controls.current?.update())
+  const controls = useMemo(() => new DeviceOrientationControlsImp(camera), [camera])
+  useFrame(() => controls.enabled && controls.update())
   useEffect(() => {
-    const currentControl = controls.current
-    currentControl?.connect()
-    return () => currentControl?.dispose()
-  })
-  return <deviceOrientationControlsImp ref={mergeRefs([controls, ref])} args={[camera]} {...props} />
+    const current = controls
+    current.connect()
+    return () => current.dispose()
+  }, [])
+  return <primitive object={controls} ref={ref} {...props} />
 })

--- a/src/controls/DeviceOrientationControls.tsx
+++ b/src/controls/DeviceOrientationControls.tsx
@@ -10,7 +10,7 @@ export type DeviceOrientationControls = Overwrite<
 export const DeviceOrientationControls = forwardRef((props: DeviceOrientationControls, ref) => {
   const { camera } = useThree()
   const controls = useMemo(() => new DeviceOrientationControlsImp(camera), [camera])
-  useFrame(() => controls.enabled && controls.update())
+  useFrame((state, delta) => controls.update(delta))
   useEffect(() => {
     const current = controls
     current.connect()

--- a/src/controls/DeviceOrientationControls.tsx
+++ b/src/controls/DeviceOrientationControls.tsx
@@ -10,7 +10,7 @@ export type DeviceOrientationControls = Overwrite<
 export const DeviceOrientationControls = forwardRef((props: DeviceOrientationControls, ref) => {
   const { camera } = useThree()
   const controls = useMemo(() => new DeviceOrientationControlsImp(camera), [camera])
-  useFrame((state, delta) => controls.update(delta))
+  useFrame(() => controls.update())
   useEffect(() => {
     const current = controls
     current.connect()

--- a/src/controls/FlyControls.tsx
+++ b/src/controls/FlyControls.tsx
@@ -10,6 +10,7 @@ export type FlyControls = Overwrite<
 export const FlyControls = forwardRef((props: FlyControls, ref) => {
   const { camera, gl } = useThree()
   const controls = useMemo(() => new FlyControlsImpl(camera, gl.domElement), [camera, gl.domElement])
-  useFrame((state, delta) => controls.update(delta))
+  useFrame((_, delta) => controls.update(delta))
+
   return <primitive object={controls} ref={ref} {...props} />
 })

--- a/src/controls/FlyControls.tsx
+++ b/src/controls/FlyControls.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo } from 'react'
+import React, { forwardRef, useMemo, useEffect } from 'react'
 import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { FlyControls as FlyControlsImpl } from 'three/examples/jsm/controls/FlyControls'
 
@@ -8,8 +8,14 @@ export type FlyControls = Overwrite<
 >
 
 export const FlyControls = forwardRef((props: FlyControls, ref) => {
-  const { camera, gl } = useThree()
+  const { camera, gl, invalidate } = useThree()
   const controls = useMemo(() => new FlyControlsImpl(camera, gl.domElement), [camera, gl.domElement])
+
+  useEffect(() => {
+    controls?.addEventListener?.('change', invalidate)
+    return () => controls?.removeEventListener?.('change', invalidate)
+  }, [controls, invalidate])
+
   useFrame((_, delta) => controls.update(delta))
 
   return <primitive object={controls} ref={ref} {...props} />

--- a/src/controls/FlyControls.tsx
+++ b/src/controls/FlyControls.tsx
@@ -1,26 +1,15 @@
-import React, { forwardRef, useRef } from 'react'
-import { ReactThreeFiber, extend, useThree, useFrame, Overwrite } from 'react-three-fiber'
+import React, { forwardRef, useMemo } from 'react'
+import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { FlyControls as FlyControlsImpl } from 'three/examples/jsm/controls/FlyControls'
-import mergeRefs from 'react-merge-refs'
-
-extend({ FlyControlsImpl })
 
 export type FlyControls = Overwrite<
   ReactThreeFiber.Object3DNode<FlyControlsImpl, typeof FlyControlsImpl>,
   { target?: ReactThreeFiber.Vector3 }
 >
 
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      flyControlsImpl: FlyControls
-    }
-  }
-}
-
 export const FlyControls = forwardRef((props: FlyControls, ref) => {
-  const controls = useRef<FlyControlsImpl>()
   const { camera, gl } = useThree()
-  useFrame((state, delta) => controls.current?.update(delta))
-  return <flyControlsImpl ref={mergeRefs([controls, ref])} args={[camera, gl.domElement]} {...props} />
+  const controls = useMemo(() => new FlyControlsImpl(camera, gl.domElement), [camera, gl.domElement])
+  useFrame((state, delta) => controls.update(delta))
+  return <primitive object={controls} ref={ref} {...props} />
 })

--- a/src/controls/FlyControls.tsx
+++ b/src/controls/FlyControls.tsx
@@ -18,5 +18,5 @@ export const FlyControls = forwardRef((props: FlyControls, ref) => {
 
   useFrame((_, delta) => controls.update(delta))
 
-  return <primitive object={controls} ref={ref} {...props} />
+  return <primitive dispose={null} object={controls} ref={ref} {...props} />
 })

--- a/src/controls/MapControls.tsx
+++ b/src/controls/MapControls.tsx
@@ -22,8 +22,8 @@ export const MapControls = forwardRef((props: MapControls = { enableDamping: tru
 
   useFrame(() => controls.update())
   useEffect(() => {
-    controls.addEventListener('change', invalidate)
-    return () => controls.removeEventListener('change', invalidate)
+    controls?.addEventListener?.('change', invalidate)
+    return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
   return <primitive object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />

--- a/src/controls/MapControls.tsx
+++ b/src/controls/MapControls.tsx
@@ -26,5 +26,5 @@ export const MapControls = forwardRef((props: MapControls = { enableDamping: tru
     return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
-  return <primitive object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />
+  return <primitive dispose={null} object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />
 })

--- a/src/controls/MapControls.tsx
+++ b/src/controls/MapControls.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useMemo, useEffect } from 'react'
-import { ReactThreeFiber, extend, useThree, useFrame, Overwrite } from 'react-three-fiber'
+import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { MapControls as MapControlsImpl } from 'three/examples/jsm/controls/OrbitControls'
 import mergeRefs from 'react-merge-refs'
 

--- a/src/controls/MapControls.tsx
+++ b/src/controls/MapControls.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef, useEffect } from 'react'
+import React, { forwardRef, useMemo, useEffect } from 'react'
 import { ReactThreeFiber, extend, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { MapControls as MapControlsImpl } from 'three/examples/jsm/controls/OrbitControls'
 import mergeRefs from 'react-merge-refs'
@@ -19,13 +19,14 @@ declare global {
 }
 
 export const MapControls = forwardRef((props: MapControls = { enableDamping: true }, ref) => {
-  const controls = useRef<MapControlsImpl>()
   const { camera, gl, invalidate } = useThree()
-  useFrame(() => controls.current?.update())
+  const controls = useMemo(() => new MapControlsImpl(camera, gl.domElement), [camera, gl])
+
+  useFrame(() => controls.update())
   useEffect(() => {
-    const _controls = controls.current
-    _controls?.addEventListener('change', invalidate)
-    return () => _controls?.removeEventListener('change', invalidate)
-  }, [invalidate])
-  return <mapControlsImpl ref={mergeRefs([controls, ref])} args={[camera, gl.domElement]} enableDamping {...props} />
+    controls.addEventListener('change', invalidate)
+    return () => controls.removeEventListener('change', invalidate)
+  }, [controls, invalidate])
+
+  return <primitive object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />
 })

--- a/src/controls/MapControls.tsx
+++ b/src/controls/MapControls.tsx
@@ -3,8 +3,6 @@ import { ReactThreeFiber, extend, useThree, useFrame, Overwrite } from 'react-th
 import { MapControls as MapControlsImpl } from 'three/examples/jsm/controls/OrbitControls'
 import mergeRefs from 'react-merge-refs'
 
-extend({ MapControlsImpl })
-
 export type MapControls = Overwrite<
   ReactThreeFiber.Object3DNode<MapControlsImpl, typeof MapControlsImpl>,
   { target?: ReactThreeFiber.Vector3 }

--- a/src/controls/OrbitControls.tsx
+++ b/src/controls/OrbitControls.tsx
@@ -29,5 +29,5 @@ export const OrbitControls = forwardRef((props: OrbitControls = { enableDamping:
     return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
-  return <primitive object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />
+  return <primitive dispose={null} object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />
 })

--- a/src/controls/OrbitControls.tsx
+++ b/src/controls/OrbitControls.tsx
@@ -29,13 +29,5 @@ export const OrbitControls = forwardRef((props: OrbitControls = { enableDamping:
     return () => controls?.removeEventListener('change', invalidate)
   }, [controls, invalidate])
 
-  return (
-    <primitive
-      object={controls}
-      ref={mergeRefs([controls, ref])}
-      args={[camera, gl.domElement]}
-      enableDamping
-      {...props}
-    />
-  )
+  return <primitive object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />
 })

--- a/src/controls/OrbitControls.tsx
+++ b/src/controls/OrbitControls.tsx
@@ -25,8 +25,8 @@ export const OrbitControls = forwardRef((props: OrbitControls = { enableDamping:
   })
 
   useEffect(() => {
-    controls?.addEventListener('change', invalidate)
-    return () => controls?.removeEventListener('change', invalidate)
+    controls?.addEventListener?.('change', invalidate)
+    return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
   return <primitive object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />

--- a/src/controls/TrackballControls.tsx
+++ b/src/controls/TrackballControls.tsx
@@ -1,9 +1,7 @@
-import React, { forwardRef, useRef, useEffect } from 'react'
-import { ReactThreeFiber, extend, useThree, useFrame, Overwrite } from 'react-three-fiber'
+import React, { forwardRef, useMemo, useEffect } from 'react'
+import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { TrackballControls as TrackballControlsImpl } from 'three/examples/jsm/controls/TrackballControls'
 import mergeRefs from 'react-merge-refs'
-
-extend({ TrackballControlsImpl })
 
 export type TrackballControls = Overwrite<
   ReactThreeFiber.Object3DNode<TrackballControlsImpl, typeof TrackballControlsImpl>,
@@ -19,13 +17,14 @@ declare global {
 }
 
 export const TrackballControls = forwardRef((props: TrackballControls, ref) => {
-  const controls = useRef<TrackballControlsImpl>()
   const { camera, gl, invalidate } = useThree()
-  useFrame(() => controls.current?.update())
+  const controls = useMemo(() => new TrackballControlsImpl(camera, gl.domElement), [camera, gl])
+
+  useFrame(() => controls.update())
   useEffect(() => {
-    const _controls = controls.current
-    _controls?.addEventListener('change', invalidate)
-    return () => _controls?.removeEventListener('change', invalidate)
-  }, [invalidate])
-  return <trackballControlsImpl ref={mergeRefs([controls, ref])} args={[camera, gl.domElement]} {...props} />
+    controls.addEventListener('change', invalidate)
+    return () => controls.removeEventListener('change', invalidate)
+  }, [controls, invalidate])
+
+  return <primitive object={controls} ref={mergeRefs([controls, ref])} {...props} />
 })

--- a/src/controls/TrackballControls.tsx
+++ b/src/controls/TrackballControls.tsx
@@ -26,5 +26,5 @@ export const TrackballControls = forwardRef((props: TrackballControls, ref) => {
     return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
-  return <primitive object={controls} ref={mergeRefs([controls, ref])} {...props} />
+  return <primitive dispose={null} object={controls} ref={mergeRefs([controls, ref])} {...props} />
 })

--- a/src/controls/TrackballControls.tsx
+++ b/src/controls/TrackballControls.tsx
@@ -22,8 +22,8 @@ export const TrackballControls = forwardRef((props: TrackballControls, ref) => {
 
   useFrame(() => controls.update())
   useEffect(() => {
-    controls.addEventListener('change', invalidate)
-    return () => controls.removeEventListener('change', invalidate)
+    controls?.addEventListener?.('change', invalidate)
+    return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
   return <primitive object={controls} ref={mergeRefs([controls, ref])} {...props} />

--- a/src/controls/TransformControls.tsx
+++ b/src/controls/TransformControls.tsx
@@ -1,12 +1,10 @@
 import { Object3D, Group } from 'three'
-import React, { forwardRef, useRef, useLayoutEffect, useEffect } from 'react'
-import { ReactThreeFiber, extend, useThree, Overwrite } from 'react-three-fiber'
+import React, { forwardRef, useRef, useLayoutEffect, useEffect, useMemo } from 'react'
+import { ReactThreeFiber, useThree, Overwrite } from 'react-three-fiber'
 import { TransformControls as TransformControlsImpl } from 'three/examples/jsm/controls/TransformControls'
 import pick from 'lodash.pick'
 import omit from 'lodash.omit'
 import mergeRefs from 'react-merge-refs'
-
-extend({ TransformControlsImpl })
 
 export type TransformControls = Overwrite<
   ReactThreeFiber.Object3DNode<TransformControlsImpl, typeof TransformControlsImpl>,
@@ -54,18 +52,21 @@ export const TransformControls = forwardRef(
     ]
     const transformProps = pick(props, transformOnlyPropNames)
     const objectProps = omit(props, transformOnlyPropNames)
-    const controls = useRef<TransformControlsImpl>()
-    const group = useRef<Group>()
+
     const { camera, gl, invalidate } = useThree()
-    useLayoutEffect(() => void controls.current?.attach(group.current as Object3D), [children])
+    const controls = useMemo(() => new TransformControlsImpl(camera, gl.domElement), [camera, gl.domElement])
+
+    const group = useRef<Group>()
+    useLayoutEffect(() => void controls.attach(group.current as Object3D), [children, controls])
+
     useEffect(() => {
-      const _controls = controls.current
-      _controls?.addEventListener('change', invalidate)
-      return () => _controls?.removeEventListener('change', invalidate)
-    }, [invalidate])
+      controls.addEventListener('change', invalidate)
+      return () => controls.removeEventListener('change', invalidate)
+    }, [controls, invalidate])
+
     return (
       <>
-        <transformControlsImpl ref={mergeRefs([controls, ref])} args={[camera, gl.domElement]} {...transformProps} />
+        <primitive object={controls} ref={mergeRefs([controls, ref])} {...transformProps} />
         <group ref={group} {...objectProps}>
           {children}
         </group>

--- a/src/controls/TransformControls.tsx
+++ b/src/controls/TransformControls.tsx
@@ -60,8 +60,8 @@ export const TransformControls = forwardRef(
     useLayoutEffect(() => void controls.attach(group.current as Object3D), [children, controls])
 
     useEffect(() => {
-      controls.addEventListener('change', invalidate)
-      return () => controls.removeEventListener('change', invalidate)
+      controls?.addEventListener?.('change', invalidate)
+      return () => controls?.removeEventListener?.('change', invalidate)
     }, [controls, invalidate])
 
     return (

--- a/src/controls/TransformControls.tsx
+++ b/src/controls/TransformControls.tsx
@@ -66,7 +66,7 @@ export const TransformControls = forwardRef(
 
     return (
       <>
-        <primitive object={controls} ref={mergeRefs([controls, ref])} {...transformProps} />
+        <primitive dispose={null} object={controls} ref={mergeRefs([controls, ref])} {...transformProps} />
         <group ref={group} {...objectProps}>
           {children}
         </group>

--- a/src/misc/Reflector.tsx
+++ b/src/misc/Reflector.tsx
@@ -1,9 +1,7 @@
 import { Mesh } from 'three'
-import React, { forwardRef } from 'react'
-import { extend, ReactThreeFiber, Overwrite } from 'react-three-fiber'
+import React, { forwardRef, useMemo } from 'react'
+import { ReactThreeFiber, Overwrite } from 'react-three-fiber'
 import { Reflector as ReflectorImpl, ReflectorOptions } from 'three/examples/jsm/objects/Reflector'
-
-extend({ ReflectorImpl })
 
 export type Reflector = Overwrite<
   ReactThreeFiber.Object3DNode<ReflectorImpl, typeof ReflectorImpl>,
@@ -21,23 +19,24 @@ declare global {
 type Props = ReflectorOptions & { children: React.ReactElement<any> }
 
 export const Reflector = forwardRef(
-  ({ children, color, textureWidth, textureHeight, clipBias, shader, encoding, ...props }: Props, ref) => (
-    <reflectorImpl
-      ref={ref as React.MutableRefObject<Mesh>}
-      args={[
-        undefined,
-        {
+  ({ children, color, textureWidth, textureHeight, clipBias, shader, encoding, ...props }: Props, ref) => {
+    const reflector = useMemo(
+      () =>
+        new ReflectorImpl(undefined, {
           color,
           textureWidth,
           textureHeight,
           clipBias,
           shader,
           encoding,
-        },
-      ]}
-      {...props}
-    >
-      {React.Children.only(children)}
-    </reflectorImpl>
-  )
+        }),
+      [clipBias, color, encoding, shader, textureHeight, textureWidth]
+    )
+
+    return (
+      <primitive object={reflector} ref={ref as React.MutableRefObject<Mesh>} {...props}>
+        {React.Children.only(children)}
+      </primitive>
+    )
+  }
 )

--- a/src/misc/Reflector.tsx
+++ b/src/misc/Reflector.tsx
@@ -34,7 +34,7 @@ export const Reflector = forwardRef(
     )
 
     return (
-      <primitive object={reflector} ref={ref as React.MutableRefObject<Mesh>} {...props}>
+      <primitive dispose={null} object={reflector} ref={ref as React.MutableRefObject<Mesh>} {...props}>
         {React.Children.only(children)}
       </primitive>
     )

--- a/src/shaders/MeshDistortMaterial.tsx
+++ b/src/shaders/MeshDistortMaterial.tsx
@@ -1,8 +1,6 @@
-import React, { useMemo, useRef } from 'react'
+import React, { useMemo } from 'react'
 import { MeshPhysicalMaterial, MeshPhysicalMaterialParameters, Shader } from 'three'
-import { extend, useFrame } from 'react-three-fiber'
-// eslint-disable-next-line
-import mergeRefs from 'react-merge-refs'
+import { useFrame } from 'react-three-fiber'
 // eslint-disable-next-line
 // @ts-ignore
 import distort from './glsl/distort.vert'

--- a/src/shaders/MeshDistortMaterial.tsx
+++ b/src/shaders/MeshDistortMaterial.tsx
@@ -92,5 +92,5 @@ export const MeshDistortMaterial = React.forwardRef(({ speed = 1, ...props }: Pr
   const material = useMemo(() => new DistortMaterialImpl(), [])
   useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
 
-  return <primitive object={material} ref={ref} attach="material" {...props} />
+  return <primitive dispose={null} object={material} ref={ref} attach="material" {...props} />
 })

--- a/src/shaders/MeshDistortMaterial.tsx
+++ b/src/shaders/MeshDistortMaterial.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useMemo, useRef } from 'react'
 import { MeshPhysicalMaterial, MeshPhysicalMaterialParameters, Shader } from 'three'
 import { extend, useFrame } from 'react-three-fiber'
 // eslint-disable-next-line
@@ -90,11 +90,9 @@ class DistortMaterialImpl extends MeshPhysicalMaterial {
   }
 }
 
-extend({ DistortMaterialImpl })
-
 export const MeshDistortMaterial = React.forwardRef(({ speed = 1, ...props }: Props, ref) => {
-  const material = useRef<DistortMaterialType>()
-  useFrame((state) => material.current && (material.current.time = state.clock.getElapsedTime() * speed))
+  const material = useMemo(() => new DistortMaterialImpl(), [])
+  useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
 
-  return <distortMaterialImpl ref={mergeRefs([ref, material])} attach="material" {...props} />
+  return <primitive object={material} ref={ref} attach="material" {...props} />
 })

--- a/src/shaders/MeshDistortMaterial.tsx
+++ b/src/shaders/MeshDistortMaterial.tsx
@@ -33,7 +33,7 @@ class DistortMaterialImpl extends MeshPhysicalMaterial {
   _distort: Uniform<number>
   _radius: Uniform<number>
 
-  constructor(parameters: MeshPhysicalMaterialParameters) {
+  constructor(parameters: MeshPhysicalMaterialParameters = {}) {
     super(parameters)
     this.setValues(parameters)
     this._time = { value: 0 }

--- a/src/shaders/MeshWobbleMaterial.tsx
+++ b/src/shaders/MeshWobbleMaterial.tsx
@@ -28,7 +28,7 @@ class WobbleMaterialImpl extends MeshStandardMaterial {
   _time: Uniform<number>
   _factor: Uniform<number>
 
-  constructor(parameters: MeshStandardMaterialParameters) {
+  constructor(parameters: MeshStandardMaterialParameters = {}) {
     super(parameters)
     this.setValues(parameters)
     this._time = { value: 0 }

--- a/src/shaders/MeshWobbleMaterial.tsx
+++ b/src/shaders/MeshWobbleMaterial.tsx
@@ -1,7 +1,6 @@
 import { MeshStandardMaterial, MeshStandardMaterialParameters, Shader } from 'three'
 import React, { useMemo } from 'react'
-import { extend, useFrame } from 'react-three-fiber'
-import mergeRefs from 'react-merge-refs'
+import { useFrame } from 'react-three-fiber'
 
 type WobbleMaterialType = JSX.IntrinsicElements['meshStandardMaterial'] & {
   time?: number

--- a/src/shaders/MeshWobbleMaterial.tsx
+++ b/src/shaders/MeshWobbleMaterial.tsx
@@ -1,5 +1,5 @@
 import { MeshStandardMaterial, MeshStandardMaterialParameters, Shader } from 'three'
-import React, { useRef } from 'react'
+import React, { useMemo } from 'react'
 import { extend, useFrame } from 'react-three-fiber'
 import mergeRefs from 'react-merge-refs'
 
@@ -73,10 +73,8 @@ class WobbleMaterialImpl extends MeshStandardMaterial {
   }
 }
 
-extend({ WobbleMaterialImpl })
-
 export const MeshWobbleMaterial = React.forwardRef(({ speed = 1, ...props }: Props, ref) => {
-  const material = useRef<WobbleMaterialType>()
-  useFrame((state) => material.current && (material.current.time = state.clock.getElapsedTime() * speed))
-  return <wobbleMaterialImpl ref={mergeRefs([ref, material])} attach="material" {...props} />
+  const material = useMemo(() => new WobbleMaterialImpl(), [])
+  useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
+  return <primitive object={material} ref={ref} attach="material" {...props} />
 })

--- a/src/shaders/MeshWobbleMaterial.tsx
+++ b/src/shaders/MeshWobbleMaterial.tsx
@@ -75,5 +75,5 @@ class WobbleMaterialImpl extends MeshStandardMaterial {
 export const MeshWobbleMaterial = React.forwardRef(({ speed = 1, ...props }: Props, ref) => {
   const material = useMemo(() => new WobbleMaterialImpl(), [])
   useFrame((state) => material && (material.time = state.clock.getElapsedTime() * speed))
-  return <primitive object={material} ref={ref} attach="material" {...props} />
+  return <primitive dispose={null} object={material} ref={ref} attach="material" {...props} />
 })

--- a/src/shaders/Sky.tsx
+++ b/src/shaders/Sky.tsx
@@ -6,8 +6,10 @@ import { Vector3 } from 'three'
 export type Sky = {
   distance?: number
   sunPosition?: ReactThreeFiber.Vector3
-  turbidity?: number
+  mieCoefficient?: number
+  mieDirectionalG?: number
   rayleigh?: number
+  turbidity?: number
 } & ReactThreeFiber.Object3DNode<SkyImpl, typeof SkyImpl>
 
 declare global {
@@ -19,7 +21,18 @@ declare global {
 }
 
 export const Sky = forwardRef<Sky>(
-  ({ distance = 100, turbidity = 2, rayleigh = 1, sunPosition = [0, Math.PI, 0], ...props }: Sky, ref) => {
+  (
+    {
+      distance = 100,
+      mieCoefficient = 0.005,
+      mieDirectionalG = 0.8,
+      rayleigh = 1,
+      turbidity = 2,
+      sunPosition = [0, Math.PI, 0],
+      ...props
+    }: Sky,
+    ref
+  ) => {
     const scale = useMemo(() => new Vector3().setScalar(distance), [distance])
     const sky = useMemo(() => new SkyImpl(), [])
 
@@ -27,9 +40,11 @@ export const Sky = forwardRef<Sky>(
       <primitive
         object={sky}
         ref={ref}
-        material-uniforms-turbidity-value={turbidity}
+        material-uniforms-mieCoefficient-value={mieCoefficient}
+        material-uniforms-mieDirectionalG-value={mieDirectionalG}
         material-uniforms-rayleigh-value={rayleigh}
         material-uniforms-sunPosition-value={sunPosition}
+        material-uniforms-turbidity-value={turbidity}
         scale={scale}
         {...props}
       />

--- a/src/shaders/Sky.tsx
+++ b/src/shaders/Sky.tsx
@@ -3,11 +3,11 @@ import { ReactThreeFiber, extend } from 'react-three-fiber'
 import { Sky as SkyImpl } from 'three/examples/jsm/objects/Sky'
 import { Vector3 } from 'three'
 
-extend({ SkyImpl })
-
 export type Sky = {
   distance?: number
   sunPosition?: ReactThreeFiber.Vector3
+  turbidity?: number
+  rayleigh?: number
 } & ReactThreeFiber.Object3DNode<SkyImpl, typeof SkyImpl>
 
 declare global {
@@ -18,7 +18,21 @@ declare global {
   }
 }
 
-export const Sky = forwardRef<Sky>(({ distance = 450000, sunPosition = [0, 1, 0], ...props }: Sky, ref) => {
-  const scale = useMemo(() => new Vector3().setScalar(distance), [distance])
-  return <skyImpl ref={ref} material-uniforms-sunPosition-value={sunPosition} scale={scale} {...props} />
-})
+export const Sky = forwardRef<Sky>(
+  ({ distance = 100, turbidity = 2, rayleigh = 1, sunPosition = [0, Math.PI, 0], ...props }: Sky, ref) => {
+    const scale = useMemo(() => new Vector3().setScalar(distance), [distance])
+    const sky = useMemo(() => new SkyImpl(), [])
+
+    return (
+      <primitive
+        object={sky}
+        ref={ref}
+        material-uniforms-turbidity-value={turbidity}
+        material-uniforms-rayleigh-value={rayleigh}
+        material-uniforms-sunPosition-value={sunPosition}
+        scale={scale}
+        {...props}
+      />
+    )
+  }
+)

--- a/src/shaders/Stars.tsx
+++ b/src/shaders/Stars.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useMemo, useRef } from 'react'
-import { useFrame, extend, ReactThreeFiber } from 'react-three-fiber'
+import { useFrame, ReactThreeFiber } from 'react-three-fiber'
 import { Points, Vector3, Spherical, Color, AdditiveBlending, ShaderMaterial } from 'three'
 
 type Props = {
@@ -39,8 +39,6 @@ class StarfieldMaterial extends ShaderMaterial {
   }
 }
 
-extend({ StarfieldMaterial })
-
 declare global {
   namespace JSX {
     interface IntrinsicElements {
@@ -72,6 +70,9 @@ export const Stars = forwardRef(
       return [new Float32Array(positions), new Float32Array(colors), new Float32Array(sizes)]
     }, [count, depth, factor, radius, saturation])
     useFrame((state) => material.current && (material.current.uniforms.time.value = state.clock.getElapsedTime()))
+
+    const starfieldMaterial = useMemo(() => new StarfieldMaterial(), [])
+
     return (
       <points ref={ref as React.MutableRefObject<Points>}>
         <bufferGeometry attach="geometry">
@@ -79,8 +80,9 @@ export const Stars = forwardRef(
           <bufferAttribute attachObject={['attributes', 'color']} args={[color, 3]} />
           <bufferAttribute attachObject={['attributes', 'size']} args={[size, 1]} />
         </bufferGeometry>
-        <starfieldMaterial
+        <primitive
           ref={material}
+          object={starfieldMaterial}
           attach="material"
           blending={AdditiveBlending}
           uniforms-fade-value={fade}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9807,10 +9807,10 @@ react-textarea-autosize@^8.1.1:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-three-fiber@^4.2.16:
-  version "4.2.17"
-  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-4.2.17.tgz#2f9e9f03d9a2bfe6e21521130965c19a39e44edf"
-  integrity sha512-7hst8PH0sJ/FbAmImXQahLxCNEtFa4+9kORuoygjwB4vLqE0z+m6w5gBWNk+ri0R4/85/o17worgcRgGcNXuSQ==
+react-three-fiber@^4.2.21:
+  version "4.2.21"
+  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-4.2.21.tgz#bb335fee090a44f2ba48762a8c42308c31f4238f"
+  integrity sha512-lbopEkL36cbAaG/y+iEGT1EFbVaVZBrOe2XGt2+HxsCL8AeWWiQQERo1HYiiqFc4p6DuoNq1hhOSxr1TKQjXuQ==
   dependencies:
     "@babel/runtime" "^7.9.2"
     "@juggle/resize-observer" "^3.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11237,10 +11237,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.119.1:
-  version "0.119.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.119.1.tgz#9d979a082c4cd9622af8e3498a8dfa026a619332"
-  integrity sha512-GHyh/RiUfQ5VTiWIVRRTANYoXc1PFB1y+jDVRTb649nif1uX1F06PT1TKU3k2+F/MN4UJ3PWvQB53fY2OqKqKw==
+three@^0.120.1:
+  version "0.120.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.120.1.tgz#dbd8894f8ab87c109f1602933e7c740c98137377"
+  integrity sha512-ktaCRFUR7JUZcKec+cBRz+oBex5pOVaJhrtxvFF2T7on53o9UkEux+/Nh1g/4zeb4t/pbxIFcADbn/ACu3LC1g==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
turns out it can't tree-shake, probably because of the extends which are called in global space.

hence, all extends have to go :-S

- [x] DeviceOrientationControls
- [x] FlyControls
- [x] Line
- [x] MapControls
- [x] MeshDistortMaterial
- [x] MeshWobbleMaterial
- [x] OrbitControls
- [x] Reflector
- [x] Sky
- [x] Stars
- [x] Text
- [x] TrackballControls
- [x] TransformControls

#### Other

- [x] Add invalidation to all controls ( needs three > 120, we are on 119 )
I added a `?.` on all addEventListeners to keep compatibility with an three version where controls don't have event listeners. Closes #72 

#### Bonus 

- [x] Added props for sky uniforms 

#### Todo

- [x] Fix types on Wobble
- [x] Fix types on Distort
- [x] Add dispose={null} to all primitives that replaced extends