### PR TITLE
Support the `dashed` prop in Line abstraction (#103)

### DIFF
--- a/.storybook/stories/Line.stories.js
+++ b/.storybook/stories/Line.stories.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { GeometryUtils } from 'three/examples/jsm/utils/GeometryUtils'
 import { Vector3 } from 'three'
 
-import { withKnobs, number, color } from '@storybook/addon-knobs'
+import { withKnobs, number, color, boolean } from '@storybook/addon-knobs'
 
 import { Setup } from '../Setup'
 
@@ -20,7 +20,7 @@ const colors = new Array(points.length).fill().map(() => [Math.random(), Math.ra
 export function BasicLine() {
   return (
     <>
-      <Line points={points} color={color('color', 'red')} lineWidth={number('lineWidth', 3)} />
+      <Line points={points} color={color('color', 'red')} lineWidth={number('lineWidth', 3)} dashed={boolean('dashed', false)} />
       <OrbitControls zoomSpeed={0.5} />
     </>
   )
@@ -39,7 +39,7 @@ BasicLine.decorators = [
 export function VertexColorsLine() {
   return (
     <>
-      <Line points={points} color={color('color', 'white')} vertexColors={colors} lineWidth={number('lineWidth', 3)} />
+      <Line points={points} color={color('color', 'white')} vertexColors={colors} lineWidth={number('lineWidth', 3)} dashed={boolean('dashed', false)} />
       <OrbitControls zoomSpeed={0.5} />
     </>
   )

--- a/src/abstractions/Line.tsx
+++ b/src/abstractions/Line.tsx
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import React, { useMemo, useEffect, useState } from 'react'
+import React, { useMemo, useEffect, useLayoutEffect, useState } from 'react'
 import { ReactThreeFiber } from 'react-three-fiber'
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry'
 import { LineMaterial, LineMaterialParameters } from 'three/examples/jsm/lines/LineMaterial'
@@ -29,10 +29,11 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
     if (vertexColors) lineGeometry.setColors(vertexColors.flat())
     line2.computeLineDistances()
   }, [points, vertexColors, line2, lineGeometry])
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (dashed) {
       lineMaterial.defines.USE_DASH = ''
     } else {
+      // Setting lineMaterial.defines.USE_DASH to undefined is apparently not sufficient.
       delete lineMaterial.defines.USE_DASH
     }
     lineMaterial.needsUpdate = true

--- a/src/abstractions/Line.tsx
+++ b/src/abstractions/Line.tsx
@@ -17,7 +17,7 @@ type Props = {
   >
 
 export const Line = React.forwardRef<Line2, Props>(function Line(
-  { points, color = 'black', vertexColors, lineWidth, ...rest },
+  { points, color = 'black', vertexColors, lineWidth, dashed, ...rest },
   ref
 ) {
   const [line2] = useState(() => new Line2())
@@ -29,6 +29,14 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
     if (vertexColors) lineGeometry.setColors(vertexColors.flat())
     line2.computeLineDistances()
   }, [points, vertexColors, line2, lineGeometry])
+  useEffect(() => {
+    if (dashed) {
+      lineMaterial.defines.USE_DASH = ''
+    } else {
+      delete lineMaterial.defines.USE_DASH
+    }
+    lineMaterial.needsUpdate = true
+  }, [dashed, lineMaterial])
   return (
     <primitive dispose={null} object={line2} ref={ref} {...rest}>
       <primitive dispose={null} object={lineGeometry} attach="geometry" />
@@ -40,6 +48,7 @@ export const Line = React.forwardRef<Line2, Props>(function Line(
         vertexColors={Boolean(vertexColors)}
         resolution={resolution}
         linewidth={lineWidth}
+        dashed={dashed}
         {...rest}
       />
     </primitive>


### PR DESCRIPTION
This PR adds support for the `dashed` prop for Drei's Line abstraction, using the advice from the below comment on the Three `webgl_lines_fat` example.

https://github.com/mrdoob/three.js/blob/22ed6755399fa180ede84bf18ff6cea0ad66f6c0/examples/webgl_lines_fat.html#L236-L239
