### PR TITLE
Draco defaults to Google CDN instead of local

### DIFF
--- a/.storybook/stories/draco.stories.js
+++ b/.storybook/stories/draco.stories.js
@@ -12,7 +12,7 @@ export default {
 }
 
 function Suzanne() {
-  const { nodes, materials } = useLoader(GLTFLoader, 'suzanne.glb', draco('draco-gltf/'))
+  const { nodes, materials } = useLoader(GLTFLoader, 'suzanne.glb', draco())
 
   return (
     <group dispose={null}>
@@ -33,3 +33,27 @@ export const DracoSceneSt = () => <DracoScene />
 DracoSceneSt.story = {
   name: 'Default',
 }
+
+function SuzanneWithLocal() {
+  const { nodes, materials } = useLoader(GLTFLoader, 'suzanne.glb', draco("/draco-gltf/"))
+
+  return (
+    <group dispose={null}>
+      <mesh material={materials['Material.001']} geometry={nodes.Suzanne.geometry} />
+    </group>
+  )
+}
+
+function DracoLocalScene() {
+  return (
+    <Suspense fallback={null}>
+      <SuzanneWithLocal />
+    </Suspense>
+  )
+}
+
+export const DracoLocalSceneSt = () => <DracoLocalScene />
+DracoLocalSceneSt.story = {
+  name: 'Local Binaries',
+}
+

--- a/src/controls/MapControls.tsx
+++ b/src/controls/MapControls.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, useMemo, useEffect } from 'react'
 import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { MapControls as MapControlsImpl } from 'three/examples/jsm/controls/OrbitControls'
-import mergeRefs from 'react-merge-refs'
 
 export type MapControls = Overwrite<
   ReactThreeFiber.Object3DNode<MapControlsImpl, typeof MapControlsImpl>,
@@ -26,5 +25,5 @@ export const MapControls = forwardRef((props: MapControls = { enableDamping: tru
     return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
-  return <primitive dispose={null} object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />
+  return <primitive dispose={null} object={controls} ref={ref} enableDamping {...props} />
 })

--- a/src/controls/OrbitControls.tsx
+++ b/src/controls/OrbitControls.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, useEffect, useMemo } from 'react'
 import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { OrbitControls as OrbitControlsImpl } from 'three/examples/jsm/controls/OrbitControls'
-import mergeRefs from 'react-merge-refs'
 
 export type OrbitControls = Overwrite<
   ReactThreeFiber.Object3DNode<OrbitControlsImpl, typeof OrbitControlsImpl>,
@@ -29,5 +28,5 @@ export const OrbitControls = forwardRef((props: OrbitControls = { enableDamping:
     return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
-  return <primitive dispose={null} object={controls} ref={mergeRefs([controls, ref])} enableDamping {...props} />
+  return <primitive dispose={null} object={controls} ref={ref} enableDamping {...props} />
 })

--- a/src/controls/TrackballControls.tsx
+++ b/src/controls/TrackballControls.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, useMemo, useEffect } from 'react'
 import { ReactThreeFiber, useThree, useFrame, Overwrite } from 'react-three-fiber'
 import { TrackballControls as TrackballControlsImpl } from 'three/examples/jsm/controls/TrackballControls'
-import mergeRefs from 'react-merge-refs'
 
 export type TrackballControls = Overwrite<
   ReactThreeFiber.Object3DNode<TrackballControlsImpl, typeof TrackballControlsImpl>,
@@ -26,5 +25,5 @@ export const TrackballControls = forwardRef((props: TrackballControls, ref) => {
     return () => controls?.removeEventListener?.('change', invalidate)
   }, [controls, invalidate])
 
-  return <primitive dispose={null} object={controls} ref={mergeRefs([controls, ref])} {...props} />
+  return <primitive dispose={null} object={controls} ref={ref} {...props} />
 })

--- a/src/controls/TransformControls.tsx
+++ b/src/controls/TransformControls.tsx
@@ -4,7 +4,6 @@ import { ReactThreeFiber, useThree, Overwrite } from 'react-three-fiber'
 import { TransformControls as TransformControlsImpl } from 'three/examples/jsm/controls/TransformControls'
 import pick from 'lodash.pick'
 import omit from 'lodash.omit'
-import mergeRefs from 'react-merge-refs'
 
 export type TransformControls = Overwrite<
   ReactThreeFiber.Object3DNode<TransformControlsImpl, typeof TransformControlsImpl>,
@@ -66,7 +65,7 @@ export const TransformControls = forwardRef(
 
     return (
       <>
-        <primitive dispose={null} object={controls} ref={mergeRefs([controls, ref])} {...transformProps} />
+        <primitive dispose={null} object={controls} ref={ref} {...transformProps} />
         <group ref={group} {...objectProps}>
           {children}
         </group>

--- a/src/loaders/draco.tsx
+++ b/src/loaders/draco.tsx
@@ -2,7 +2,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
 import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
 import { Loader } from 'three'
 
-export function draco(url: string = '/draco-gltf/') {
+export function draco(url: string = 'https://www.gstatic.com/draco/v1/decoders/') {
   return (loader: Loader) => {
     const dracoLoader = new DRACOLoader()
     dracoLoader.setDecoderPath(url)


### PR DESCRIPTION
This removes the requirement of having to ship the `draco` binaries with projects, CDN should be ok for 99% of the users.

It's still possible to specify draco binaries path for both `draco` and `useGLTFLoader`